### PR TITLE
Import from this repo rather than original micdoher repo, and fix TestConfigResolveDN test

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Use the default setting during the install process for GOlang
 #### Create the required directory structure
 
 ```
+mkdir -p ~/Users/yourlocalusernamehere/go/src/github.com/CiscoUcs
 mkdir -p ~/Users/yourlocalusernamehere/go/src/github.com/micdoher
 ```
 
@@ -67,20 +68,20 @@ export  PATH=$PATH:/Users/yourlocalusernamehere/go
 
 ### Clone the Git binaries
 
-Clone the terraform-provider-ucs into ```/Users/yourlocalusernamehere/go/src/github.com/micdoher/``` via the following command: -
+Clone the UCS-Terraform provider repo into ```/Users/yourlocalusernamehere/go/src/github.com/CiscoUcs/``` via the following command: -
 
+
+```
+cd ~/Users/yourlocalusernamehere/go/src/github.com/CiscoUcs/
+git clone https://github.com/CiscoUcs/UCS-Terraform.git
+```
+
+Clone the “go-utils” repo into ```/Users/yourlocalusernamehere/go/src/github.com/micdoher``` with the following command: -
 
 ```
 cd ~/Users/yourlocalusernamehere/go/src/github.com/micdoher/
-git clone https://github.com/micdoher/terraform-provider-ucs.git
-```
-
-Clone the “go-utils” into ```/Users/yourlocalusernamehere/go/src/github.com/micdoher``` with the following command: -
-
-```
 git clone https://github.com/micdoher/GoUtils.git
 ```
-
 
 ### Compiling and dependency setup
 
@@ -91,7 +92,7 @@ After the terraform provider has been cloned, the resulting directory structure 
 
 Now navigate to:
 ```
-cd /Users/yourlocalusernamehere/go/src/github.com/CiscoCloud/terraform-provider-ucs
+cd /Users/yourlocalusernamehere/go/src/github.com/CiscoUcs/UCS-Terraform
 ```
 
 
@@ -215,13 +216,13 @@ Error configuring: 1 error(s) occurred:
 The following error means the directory structure is not setup correclty: 
 
 ```
-terraform-provider-ucs-master micdoher$ go build -o terraform-provider-ucs
-resource_ucs_service_profile.go:8:2: cannot find package "github.com/CiscoCloud/terraform-provider-ucs/ipman" in any of:
-    /usr/local/go/src/github.com/CiscoCloud/terraform-provider-ucs/ipman (from $GOROOT)
-    /Users/yourname/terraform/terraform-provider-ucs-master/src/github.com/CiscoCloud/terraform-provider-ucs/ipman (from $GOPATH)
-provider.go:4:2: cannot find package "github.com/CiscoCloud/terraform-provider-ucs/ucsclient" in any of:
-    /usr/local/go/src/github.com/CiscoCloud/terraform-provider-ucs/ucsclient (from $GOROOT)
-    /Users/yourname/terraform/terraform-provider-ucs-master/src/github.com/CiscoCloud/terraform-provider-ucs/ucsclient (from $GOPATH)
+terraform-provider-ucs-master UCS-Terraform$ go build -o terraform-provider-ucs
+resource_ucs_service_profile.go:8:2: cannot find package "github.com/CiscoUcs/UCS-Terraform/ipman" in any of:
+    /usr/local/go/src/github.com/CiscoUcs/UCS-Terraform/ipman (from $GOROOT)
+    /Users/yourname/terraform/terraform-provider-ucs-master/src/github.com/CiscoUcs/UCS-Terraform/ipman (from $GOPATH)
+provider.go:4:2: cannot find package "github.com/CiscoUcs/UCS-Terraform/ucsclient" in any of:
+    /usr/local/go/src/github.com/CiscoUcs/UCS-Terraform/ucsclient (from $GOROOT)
+    /Users/yourname/terraform/terraform-provider-ucs-master/src/github.com/CiscoUcs/UCS-Terraform/ucsclient (from $GOPATH)
 ```
 
 If you get the following error when running this from a Mac ```xcrun: error: invalid active developer path (/Library/Developer/CommandLineTools), missing xcrun at: /Library/Developer/CommandLineTools/usr/bin/xcrun```

--- a/provider.go
+++ b/provider.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/micdoher/terraform-provider-ucs/ucsclient"
+	"github.com/CiscoUcs/UCS-Terraform/ucsclient"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 )

--- a/resource_ucs_service_profile.go
+++ b/resource_ucs_service_profile.go
@@ -5,8 +5,8 @@ import (
 	"net"
 	"sync"
 
-	"github.com/micdoher/terraform-provider-ucs/ipman"
-	"github.com/micdoher/terraform-provider-ucs/ucsclient"
+	"github.com/CiscoUcs/UCS-Terraform/ipman"
+	"github.com/CiscoUcs/UCS-Terraform/ucsclient"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 

--- a/ucsclient/ucsclient.go
+++ b/ucsclient/ucsclient.go
@@ -14,7 +14,7 @@ import (
 	"os"
 	"strings"
 
-	ucs "github.com/micdoher/terraform-provider-ucs/ucsclient/ucsinternal"
+	ucs "github.com/CiscoUcs/UCS-Terraform/ucsclient/ucsinternal"
 	"github.com/micdoher/GoUtils"
 	xmlpath "gopkg.in/xmlpath.v2"
 )

--- a/ucsclient/ucsclient_test.go
+++ b/ucsclient/ucsclient_test.go
@@ -361,10 +361,10 @@ func TestLogout(t *testing.T) {
 }
 
 func TestConfigResolveDN(t *testing.T) {
-	req, err := utils.Fixture("config-resolve-dn-req.xml")
+	req, err := ioutil.ReadFile("testdata/config-resolve-dn-req.xml")
 	utils.FailOnError(t, err)
 
-	res, err := utils.Fixture("config-resolve-dn-res.xml")
+	res, err := ioutil.ReadFile("testdata/config-resolve-dn-res.xml")
 	utils.FailOnError(t, err)
 
 	dn := "org-root/ls-foobar"


### PR DESCRIPTION
This PR updates the imports and README to ensure imports are from this repo and not the original
`github.com/micdoher/terraform-provider-ucs` repo, as it stands you'd require both this repo and the original to build.

It also fixes the `TestConfigResolveDN` test which had been broken by #3 and the move to using `testdata/` for fixtures.